### PR TITLE
Add noopener for the Github link pointed by this website

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -60,7 +60,7 @@
             <p class="lead">{{.Site.Params.Description}}</p>
             <p>Interested and align with our <a href="https://oxide.computer/principles/">principles of operation</a>?<br />
                 Send a PR with any improvement to <a
-                    href="https://github.com/oxidecomputer/design.oxide.computer" target="_blank" rel="noreferrer">this
+                    href="https://github.com/oxidecomputer/design.oxide.computer" target="_blank" rel="noreferrer noopener">this
                     repo on GitHub</a>
                     or <a href="https://oxide.computer/careers/product-engineers/" target="_blank">apply
                     through our careers page</a>.


### PR DESCRIPTION
Not a design change.

Followed this article https://mathiasbynens.github.io/rel-noopener/ and added `noopener` to a Github link.